### PR TITLE
Corrects quite to quiet, they're sometimes confused with each other.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -63,7 +63,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: node index.js https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml
-      - run: node index.js https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --quite
+      - run: node index.js https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --quiet
       - run: node index.js https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --no-css
       - run: node index.js https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --no-js
       - run: node index.js https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --no-images
@@ -81,7 +81,7 @@ jobs:
           name: docker-image
       - run: docker load -i sitemap-warmer.tar
       - run: docker run sitemap-warmer:local https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml
-      - run: docker run sitemap-warmer:local https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --quite
+      - run: docker run sitemap-warmer:local https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --quiet
       - run: docker run sitemap-warmer:local https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --no-css
       - run: docker run sitemap-warmer:local https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --no-js
       - run: docker run sitemap-warmer:local https://raw.githubusercontent.com/tdtgit/sitemap-warmer/master/tests/sitemap.xml --no-images

--- a/README.md
+++ b/README.md
@@ -81,17 +81,19 @@ Usage:
 warmup datuan.dev <URL> <parameter>
 ```
 
-| Parameter            | Description                                                                                                            | Default            |
-|------------------	|---------------------------------------------------------------------------------------------------------------------	|-----------------	|
-| `-a`, `--all`        | Warm up all URLs in sitemap                                                                                            | False            |
-| `-r`, `--range`    | Only warm up URLs with `lastMod` newer than X seconds.<br> This parameters is ignored if `-a` (`--all`) is provided    | 300s (5 minutes)    |
-| `-d`, `--delay`    | Delay (in milliseconds) between each warm up call.<br> If you using the low-end hosting, keep this value higher        | 500                |
-| `--no-images`    | Disable images warm up                                                                                               | False                |
-| `--no-css`    | Disable CSS warm up                                                                                               | False                |
-| `--no-js`    | Disable Javascript warm up                                                                                               | False                |
-| `--no-brotli`    | Disable Brotli compression warm up                                                                                               | False                |
-| `-q`, `--quiet`    | Suppress the debug log                                                                                                | False            |
-| `-h`, `--headers`    | Add custom headers                                                                                                | None            |
+| Parameter           | Description                                                                                                           | Default           |
+|-------------------- |---------------------------------------------------------------------------------------------------------------------  |-----------------  |
+| `-a`, `--all`       | Warm up all URLs in sitemap                                                                                           | False             |
+| `-r`, `--range`     | Only warm up URLs with `lastMod` newer than X seconds.<br> This parameters is ignored if `-a` (`--all`) is provided   | 300s (5 minutes)  |
+| `-d`, `--delay`     | Delay (in milliseconds) between each warm up call.<br> If you using the low-end hosting, keep this value higher       | 500               |
+| `--images`          | Enables images warm up                                                                                                | True              |
+| `--webp`            | Enables webp images warm up                                                                                           | True              |
+| `--avif`            | Enables avif images warm up                                                                                           | True              |
+| `--css`             | Enables CSS warm up                                                                                                   | True              |
+| `--js`              | Enables Javascript warm up                                                                                            | True              |
+| `--brotli`          | Enables Brotli compression warm up (all modern browsers support it)                                                   | True              |
+| `-q`, `--quiet`     | Suppress the debug log                                                                                                | False             |
+| `-h`, `--headers`   | Add custom headers                                                                                                    | None              |
 
 ## Advanced options
 ### Custom request headers

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ warmup datuan.dev <URL> <parameter>
 | `--no-css`    | Disable CSS warm up                                                                                               | False                |
 | `--no-js`    | Disable Javascript warm up                                                                                               | False                |
 | `--no-brotli`    | Disable Brotli compression warm up                                                                                               | False                |
-| `-q`, `--quite`    | Suppress the debug log                                                                                                | False            |
+| `-q`, `--quiet`    | Suppress the debug log                                                                                                | False            |
 | `-h`, `--headers`    | Add custom headers                                                                                                | None            |
 
 ## Advanced options

--- a/index.js
+++ b/index.js
@@ -30,8 +30,8 @@ const argv = yargs(process.argv.slice(2))
     .default('avif', true)
     .alias('a', 'all')
     .describe('all', 'Ignore --range parameter and warm up all URLs in sitemap')
-    .alias('q', 'quite')
-    .describe('quite', 'Disable debug logging if you feel it\'s too much')
+    .alias('q', 'quiet')
+    .describe('quiet', 'Disable debug logging if you feel it\'s too much')
     .alias('p', 'purge')
     .describe('purge', 'Enable purging the resources before warm up.')
     .default('purge', 0)
@@ -43,7 +43,7 @@ const logger = Logger.create('main', {
     useLocalTime: true,
 })
 
-if (argv.quite) {
+if (argv.quiet) {
     Logger.setLogLevel(Logger.LogLevels.INFO)
 }
 


### PR DESCRIPTION
Maybe a better option would be --silent or -s?